### PR TITLE
Fixes for configure_katello_proxy behaviour

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,17 @@
 configure_katello_nailgun_package: nailgun
 configure_katello_username: admin
 configure_katello_password: "{{ vault_katello_admin_password | default('changeme') }}"
-configure_katello_server_url: "https://{{ ansible_fqdn }}"
+configure_katello_server_url: "https://{{ inventory_hostname }}"
+# ansible_fqdn picks up internal hostname with EC2 instances
+# configure_katello_server_url: "https://{{ ansible_fqdn }}"
 configure_katello_verify_ssl: false
 configure_katello_install_deps: true
 configure_katello_copy_manifest: false
 configure_katello_force_manifest_upload: false
+
+# configure_katello_proxy: http://bungabunga.com
+# configure_katello_proxy_username: myuser
+# configure_katello_proxy_password: itspassword
 
 #configure_katello_organizations:
 #  - { name: AMCE, state: present, manifest: "{{ ansible_fqdn }}" }

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,11 +15,6 @@
     name: python-pip
     state: present
 
-- name: test is defined
-  debug:
-    msg: Uhhhhhh
-    # msg: "{{ build_extra_args }}"
-
 - name: Build extra arguments when configure_katello_proxy is defined
   set_fact:
     build_extra_args: "{{ '--proxy ' + (configure_katello_proxy | urlsplit('scheme')) + '://' + configure_katello_proxy_username + ':' + configure_katello_proxy_password + '@' + (configure_katello_proxy | urlsplit('hostname')) + ':' + (configure_katello_proxy | urlsplit('port') | string) }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,9 +15,20 @@
     name: python-pip
     state: present
 
+- name: test is defined
+  debug:
+    msg: Uhhhhhh
+    # msg: "{{ build_extra_args }}"
+
+- name: Build extra arguments when configure_katello_proxy is defined
+  set_fact:
+    build_extra_args: "{{ '--proxy ' + (configure_katello_proxy | urlsplit('scheme')) + '://' + configure_katello_proxy_username + ':' + configure_katello_proxy_password + '@' + (configure_katello_proxy | urlsplit('hostname')) + ':' + (configure_katello_proxy | urlsplit('port') | string) }}"
+  when:
+    configure_katello_proxy is defined
+
 - name: Install nailgun
   pip:
     name: "{{ configure_katello_nailgun_package }}"
     version: "{{ configure_katello_nailgun_version | default(omit) }}"
     virtualenv: "{{ configure_katello_virtualenv | default(omit) }}"
-    extra_args: "{{ (configure_katello_proxy is defined) | ternary('--proxy ' + (configure_katello_proxy | urlsplit('scheme')) + '://' + configure_katello_proxy_username + ':' + configure_katello_proxy_password + '@' + (configure_katello_proxy | urlsplit('hostname')) + ':' + (configure_katello_proxy | urlsplit('port') | string), '') }}"
+    extra_args: "{{ build_extra_args }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+build_extra_args: ""


### PR DESCRIPTION
Fixing the scenario where `configure_katello_proxy` _isn't_ set.  Tested both with and without `configure_katello_proxy`.

Added example configure_katello_proxy in the defaults so it's obvious it needs to be the full URI rather than just an FQDN (this threw me for a while, so I think it's worthwhile).